### PR TITLE
Fix uninitialized field in t_field constructor causing issues with sandesh

### DIFF
--- a/compiler/parse/t_field.h
+++ b/compiler/parse/t_field.h
@@ -39,6 +39,9 @@ class t_field : public t_doc {
     type_(type),
     name_(name),
     key_(0),
+#ifdef SANDESH
+    req_(T_OPT_IN_REQ_OUT),
+#endif
     value_(NULL),
     xsd_optional_(false),
     xsd_nillable_(false),


### PR DESCRIPTION
Initialize req_ in t_field constructor with T_OPT_IN_REQ_OUT to prevent issues with sandesh code generation
