### PR TITLE
Patch in: c6dc75cc271ca8d3cb2615386f8ca24685d54d7b

### DIFF
--- a/library/cpp/sandesh_session.h
+++ b/library/cpp/sandesh_session.h
@@ -41,7 +41,6 @@ public:
         tbb::mutex::scoped_lock lock(mutex_);
         return ready_to_send_;
     }
-    int WaitMsgQSize() { return wait_msgq_.size(); }
 
     static const std::string sandesh_open_;
     static const std::string sandesh_open_attr_length_;
@@ -56,8 +55,6 @@ protected:
 
 private:
     friend class SandeshSendMsgUnitTest;
-
-    typedef std::vector<boost::shared_ptr<TMemoryBuffer> > WaitMsgQ;
 
     TcpSession *session_;
 
@@ -81,7 +78,6 @@ private:
     SandeshSession *session();
 
     bool ready_to_send_;
-    WaitMsgQ wait_msgq_;
     tbb::mutex mutex_;
     // send_buf_ is used to store unsent data
     uint8_t *send_buf_;

--- a/library/cpp/test/sandesh_session_test.cc
+++ b/library/cpp/test/sandesh_session_test.cc
@@ -110,13 +110,13 @@ private:
         bool ret = true;
 
         if (NO_SEND == send_action) {
-            *sent = 0;
-            return false;
+            if (sent) *sent = 0;
+            ret = false;
         } else if (PARTIAL_SEND == send_action) {
-            *sent = size/2;
+            if (sent) *sent = size/2;
             ret = false;
         } else if (SEND == send_action) {
-            *sent = size;
+            if (sent) *sent = size;
         }
 
         LOG(DEBUG, "Send: [" << size << "] bytes");
@@ -486,33 +486,20 @@ TEST_F(SandeshSendMsgUnitTest, AsyncSend) {
     send_action = NO_SEND;
     session_->SendMessage(msg_info[cnt].buf,
                          msg_info[cnt].msg_size, false);
-    EXPECT_EQ(0, session_->send_count());
+    EXPECT_EQ(1, session_->send_count());
     EXPECT_EQ(0, send_buf_offset());
-    EXPECT_EQ(1, session_->writer()->WaitMsgQSize());
     EXPECT_EQ(0, session_->writer()->SendReady());
 
     cnt++; // 1
     session_->SendMessage(msg_info[cnt].buf,
                          msg_info[cnt].msg_size, false);
-    EXPECT_EQ(0, session_->send_count());
+    EXPECT_EQ(2, session_->send_count());
     EXPECT_EQ(0, send_buf_offset());
-    EXPECT_EQ(2, session_->writer()->WaitMsgQSize());
     EXPECT_EQ(0, session_->writer()->SendReady());
 
     send_action = PARTIAL_SEND;
     session_->WriteReady(ec);
-    EXPECT_EQ(1, session_->send_count());
-    EXPECT_EQ(1, session_->writer()->WaitMsgQSize());
-    EXPECT_EQ(0, session_->writer()->SendReady());
-
-    session_->WriteReady(ec);
     EXPECT_EQ(2, session_->send_count());
-    EXPECT_EQ(0, session_->writer()->WaitMsgQSize());
-    EXPECT_EQ(0, session_->writer()->SendReady());
-
-    session_->WriteReady(ec);
-    EXPECT_EQ(2, session_->send_count());
-    EXPECT_EQ(0, session_->writer()->WaitMsgQSize());
     EXPECT_EQ(1, session_->writer()->SendReady());
 
     cnt++; // 2
@@ -520,22 +507,19 @@ TEST_F(SandeshSendMsgUnitTest, AsyncSend) {
                          msg_info[cnt].msg_size, false);
     EXPECT_EQ(3, session_->send_count());
     EXPECT_EQ(0, send_buf_offset());
-    EXPECT_EQ(0, session_->writer()->WaitMsgQSize());
     EXPECT_EQ(0, session_->writer()->SendReady());
 
     cnt++; // 3
     session_->SendMessage(msg_info[cnt].buf,
                          msg_info[cnt].msg_size, false);
-    EXPECT_EQ(3, session_->send_count());
+    EXPECT_EQ(4, session_->send_count());
     EXPECT_EQ(0, send_buf_offset());
-    EXPECT_EQ(1, session_->writer()->WaitMsgQSize());
     EXPECT_EQ(0, session_->writer()->SendReady());
 
     send_action = SEND;
     session_->WriteReady(ec);
     EXPECT_EQ(4, session_->send_count());
     EXPECT_EQ(0, send_buf_offset());
-    EXPECT_EQ(0, session_->writer()->WaitMsgQSize());
     EXPECT_EQ(1, session_->writer()->SendReady());
 
     for (int i = 0; i < session_->send_count(); i++) {


### PR DESCRIPTION
commit c6dc75cc271ca8d3cb2615386f8ca24685d54d7b
Author: Megh Bhatt meghb@juniper.net
Date:   Thu Dec 5 10:20:05 2013 -0800

```
Remove wait_msgq from SandeshWriter since TcpSession Send already
buffers the unsent data. This helps simplify the SandeshSession/
SandeshWriter send code. SendInternal updates the ready_to_send
flag based on the TcpSession Send. In WriteReady callback, set
ready_to_send to true and kickstart the send queue processing.
```
