### PR TITLE
Fix for #2092

### DIFF
--- a/library/python/pysandesh/sandesh_req_impl.py
+++ b/library/python/pysandesh/sandesh_req_impl.py
@@ -24,7 +24,7 @@ from pysandesh.gen_py.sandesh_trace.ttypes import SandeshTraceBufInfo, \
     SandeshTraceBufStatusReq, SandeshTraceBufStatusRes, \
     SandeshTraceBufferEnableDisableReq, SandeshTraceBufferEnableDisableRes, \
     SandeshTraceBufStatusInfo
-
+from pysandesh.gen_py.sandesh_uve.ttypes import SandeshQueueStats
 
 class SandeshReqImpl(object):
 


### PR DESCRIPTION
Missing import for SandeshQueueStats in sandesh_req_impl.py caused exception on execution of the SandeshMessageStatsReq in introspect.
