### PR TITLE
Patch in: e9572f3e8e78ca5ce44b7e0ec84568dea97adb8c

### DIFF
--- a/library/cpp/sandesh_server.cc
+++ b/library/cpp/sandesh_server.cc
@@ -25,6 +25,7 @@ using namespace boost::asio;
 
 const std::string SandeshServer::kStateMachineTask = "sandesh::SandeshStateMachine";
 const std::string SandeshServer::kLifetimeMgrTask = "sandesh::LifetimeMgr";
+const std::string SandeshServer::kSessionReaderTask = "io::ReaderTask";
 
 class SandeshServer::DeleteActor : public LifetimeActor {
 public:
@@ -47,6 +48,7 @@ bool SandeshServer::task_policy_set_ = false;
 SandeshServer::SandeshServer(EventManager *evm)
     : TcpServer(evm),
       sm_task_id_(TaskScheduler::GetInstance()->GetTaskId(kStateMachineTask)),
+      session_reader_task_id_(TaskScheduler::GetInstance()->GetTaskId(kSessionReaderTask)),
       lifetime_mgr_task_id_(TaskScheduler::GetInstance()->GetTaskId(kLifetimeMgrTask)),
       lifetime_manager_(new LifetimeManager(lifetime_mgr_task_id_)),
       deleter_(new DeleteActor(this)) {

--- a/library/cpp/sandesh_server.h
+++ b/library/cpp/sandesh_server.h
@@ -67,10 +67,10 @@ protected:
     virtual bool AcceptSession(TcpSession *session);
     // Session read, write, and state machine tasks run exclusively
     int session_writer_task_id() const { return sm_task_id_; }
-    int session_reader_task_id() const { return sm_task_id_; }
+    int session_reader_task_id() const { return session_reader_task_id_; }
 
 private:
-    static const std::string kSessionTask;
+    static const std::string kSessionReaderTask;
     static const std::string kStateMachineTask;
     static const std::string kLifetimeMgrTask;
     static bool task_policy_set_;
@@ -88,6 +88,7 @@ private:
     SandeshConnectionMap connection_;
     boost::dynamic_bitset<> conn_bmap_;
     int sm_task_id_;
+    int session_reader_task_id_;
     int lifetime_mgr_task_id_;
     boost::scoped_ptr<LifetimeManager> lifetime_manager_;
     boost::scoped_ptr<DeleteActor> deleter_;


### PR DESCRIPTION
commit e9572f3e8e78ca5ce44b7e0ec84568dea97adb8c
Author: Megh Bhatt meghb@juniper.net
Date:   Mon Dec 30 16:51:38 2013 -0800

```
1. Change TCP session reader task for vizd from the sandesh state
   machine task to the IO reader task so that the sandesh message
   reading and processing can happen in parallel. This reverts the
   change done as part of bug 1729 to make the session reader task
   and state machine task exclusive. The issue mentioned in bug
   1729 is handled by setting the session sandesh message receive
   callback to NULL as part of session delete/close which happens
   from the state machine task.
2. Increase the VizSession receive buffer size to 16K from 4K
   since the Sandesh client average send is around 10K bytes.

With the above 2 changes, on a single box setup, vizd is able to
receive 50K flow samples at steady state with no drops on the sandesh
client.
```
