### PR TITLE
Analytics instance id support & all fields table removal

### DIFF
--- a/compiler/generate/t_py_generator.cc
+++ b/compiler/generate/t_py_generator.cc
@@ -1414,6 +1414,8 @@ void t_py_generator::generate_py_sandesh_definition(ofstream& out,
     indent(out) << "self._scope = sandesh.scope()" << endl;
     indent(out) << "self._module = sandesh.module()" << endl;
     indent(out) << "self._source = sandesh.source_id()" << endl;
+    indent(out) << "self._node_type = sandesh.node_type()" << endl;
+    indent(out) << "self._instance_id = sandesh.instance_id()" << endl;
     indent(out) << "self._seqnum = 0" << endl;
     indent(out) << "self._timestamp = UTCTimestampUsec()" << endl;
     indent(out) << "self._versionsig = " << tsandesh->get_4byte_fingerprint() << endl; 

--- a/library/common/sandesh.sandesh
+++ b/library/common/sandesh.sandesh
@@ -70,4 +70,6 @@ struct SandeshHeader {
     9: i32 Hints;
     10: i32 Level;
     11: string Category;
+    12: string NodeType;
+    13: string InstanceId;
 }

--- a/library/common/sandesh_ctrl.sandesh
+++ b/library/common/sandesh_ctrl.sandesh
@@ -15,6 +15,8 @@ request sandesh SandeshCtrlClientToServer {
     4: list<string> uve_types;
     5: u32 pid;
     6: u32 http_port;
+    7: string node_type_name;
+    8: string instance_id_name;
 }
 
 struct UVETypeInfo {

--- a/library/cpp/sandesh.h
+++ b/library/cpp/sandesh.h
@@ -158,26 +158,39 @@ public:
     // Initialization APIs
     static bool InitGenerator(const std::string &module,
             const std::string &source,
+            const std::string &node_type,
+            const std::string &instance_id,
             EventManager *evm,
             unsigned short http_port,
             CollectorSubFn csf,
-            const std::vector<std::string> collectors,
+            const std::vector<std::string> &collectors,
             SandeshContext *client_context = NULL);
-    static void InitCollector(const std::string module,
-            const std::string source, EventManager *evm,
-            const std::string collector_ip, int collector_port,
+    static void InitGenerator(const std::string &module,
+            const std::string &source, 
+            const std::string &node_type,
+            const std::string &instance_id,
+            EventManager *evm,
             unsigned short http_port,
             SandeshContext *client_context = NULL);
-    static void InitGenerator(const std::string module,
-            const std::string source, EventManager *evm,
+    // Collector
+    static void InitCollector(const std::string &module,
+            const std::string &source, 
+            const std::string &node_type,
+            const std::string &instance_id,
+            EventManager *evm,
+            const std::string &collector_ip, int collector_port,
             unsigned short http_port,
             SandeshContext *client_context = NULL);
-    static bool ConnectToCollector(const std::string collector_ip,
+    // Test
+    static void InitGeneratorTest(const std::string &module,
+            const std::string &source,
+            const std::string &node_type,
+            const std::string &instance_id, 
+            EventManager *evm,
+            unsigned short http_port,
+            SandeshContext *client_context = NULL);
+    static bool ConnectToCollector(const std::string &collector_ip,
             int collector_port);
-    static void InitGeneratorTest(const std::string module,
-            const std::string source, EventManager *evm,
-            unsigned short http_port,
-            SandeshContext *client_context = NULL);
     static void Uninit();
 
     // Logging and category APIs
@@ -240,10 +253,14 @@ public:
     bool IsLoggingAllowed();
 
     // Accessors
-    static void set_source(std::string source) { source_ = source; }
+    static void set_source(std::string &source) { source_ = source; }
     static std::string source() { return source_; }
-    static void set_module(std::string module) { module_ = module; }
+    static void set_module(std::string &module) { module_ = module; }
     static std::string module() { return module_; }
+    static void set_instance_id(std::string &instance_id) { instance_id_ = instance_id; }
+    static std::string instance_id() { return instance_id_; }
+    static void set_node_type(std::string &node_type) { node_type_ = node_type; }
+    static std::string node_type() { return node_type_; }
     static SandeshRole role() { return role_; }
     static uint32_t http_port() { return http_port_; }
     static SandeshRxQueue* recv_queue() { return recv_queue_.get(); }
@@ -300,9 +317,15 @@ private:
 
     static void InitReceive(int recv_task_inst = -1);
     static void InitClient(EventManager *evm, Endpoint server);
+    static bool InitClient(EventManager *evm, 
+                           const std::vector<std::string> &collectors,
+                           CollectorSubFn csf);
     static bool ProcessRecv(SandeshRequest *);
-    static void Initialize(SandeshRole role, const std::string module,
-            const std::string source, EventManager *evm,
+    static void Initialize(SandeshRole role, const std::string &module,
+            const std::string &source, 
+            const std::string &node_type,
+            const std::string &instance_id,
+            EventManager *evm,
             unsigned short http_port,
             SandeshContext *client_context = NULL);
 
@@ -311,6 +334,8 @@ private:
     static SandeshRole role_;
     static std::string module_;
     static std::string source_;
+    static std::string node_type_;
+    static std::string instance_id_;
     static uint32_t http_port_;
     static std::auto_ptr<SandeshRxQueue> recv_queue_;
     static int recv_task_id_;

--- a/library/cpp/sandesh_client.cc
+++ b/library/cpp/sandesh_client.cc
@@ -251,10 +251,13 @@ void SandeshClient::InitializeSMSession(int count) {
     for(; it!= SandeshUVETypeMaps::End(); it++) {
         stv.push_back(it->first);
     }
-    LOG(DEBUG, "Sending Ctrl Message for " << Sandesh::module() << " count " << count);
+    LOG(DEBUG, "Sending Ctrl Message for " << Sandesh::source() << ":" <<
+        Sandesh::module() << ":" << Sandesh::instance_id() << ":" <<
+        Sandesh::node_type() << " count " << count);
 
     SandeshCtrlClientToServer::Request(Sandesh::source(), Sandesh::module(),
-            count, stv, getpid(), Sandesh::http_port(), "ctrl");
+            count, stv, getpid(), Sandesh::http_port(),
+            Sandesh::node_type(), Sandesh::instance_id(), "ctrl");
 
 }
 
@@ -265,7 +268,8 @@ void SandeshClient::SendUVE(int count,
         const string & stateName, const string & server,
         Endpoint primary, Endpoint secondary) {
     ModuleClientState mcs;
-    mcs.set_name(Sandesh::source() + ":" + Sandesh::module());
+    mcs.set_name(Sandesh::source() + ":" + Sandesh::node_type() +
+        ":" + Sandesh::module() + ":" + Sandesh::instance_id());
     SandeshClientInfo sci;
     if (!client_start) {
         client_start_time = UTCTimestampUsec(); 

--- a/library/cpp/sandesh_client_sm.cc
+++ b/library/cpp/sandesh_client_sm.cc
@@ -858,7 +858,8 @@ SandeshClientSMImpl::SandeshClientSMImpl(EventManager *evm, Mgr *mgr,
         dequeues_(0),
         dequeue_fails_(0) {
     state_ = IDLE;
-    generator_key_ = Sandesh::source() + ":" + Sandesh::module();
+    generator_key_ = Sandesh::source() + ":" + Sandesh::node_type() + ":" + 
+        Sandesh::module() + ":" + Sandesh::instance_id();
     initiate();
     StartStatisticsTimer();
 }

--- a/library/cpp/sandesh_session.cc
+++ b/library/cpp/sandesh_session.cc
@@ -95,6 +95,8 @@ void SandeshWriter::SendMsg(Sandesh *sandesh, bool more) {
     header.set_Hints(sandesh->hints());
     header.set_Level(sandesh->level());
     header.set_Category(sandesh->category());
+    header.set_NodeType(sandesh->node_type());
+    header.set_InstanceId(sandesh->instance_id());
 
     // Write the sandesh open envelope.
     buffer = btrans->getWritePtr(sandesh_open_.length());
@@ -103,8 +105,9 @@ void SandeshWriter::SendMsg(Sandesh *sandesh, bool more) {
     // Write the sandesh header
     if ((ret = header.write(prot)) < 0) {
         LOG(ERROR, __func__ << ": Sandesh header write FAILED: " <<
-            sandesh->Name() << " : Source:" << sandesh->source() << " Module:" <<
-            sandesh->module() << " Sequence Number:" << sandesh->seqnum());
+            sandesh->Name() << " : " << sandesh->source() << ":" <<
+            sandesh->module() << ":" << sandesh->instance_id() <<
+            " Sequence Number:" << sandesh->seqnum());
         session()->increment_send_msg_fail();
         Sandesh::UpdateSandeshStats(sandesh->Name(), 0, true, true);
         sandesh->Release();
@@ -114,8 +117,9 @@ void SandeshWriter::SendMsg(Sandesh *sandesh, bool more) {
     // Write the sandesh
     if ((ret = sandesh->Write(prot)) < 0) {
         LOG(ERROR, __func__ << ": Sandesh write FAILED: "<<
-            sandesh->Name() << " : Source:" << sandesh->source() << " Module:" <<
-            sandesh->module() << " Sequence Number:" << sandesh->seqnum());
+            sandesh->Name() << " : " << sandesh->source() << ":" <<
+            sandesh->module() << ":" << sandesh->instance_id() <<
+            " Sequence Number:" << sandesh->seqnum());
         session()->increment_send_msg_fail();
         Sandesh::UpdateSandeshStats(sandesh->Name(), 0, true, true);
         sandesh->Release();

--- a/library/cpp/test/sandesh_message_test.cc
+++ b/library/cpp/test/sandesh_message_test.cc
@@ -227,7 +227,8 @@ TEST_F(SandeshAsyncTest, Async) {
     int port = server_->GetPort();
     ASSERT_LT(0, port);
     // Connect to the server
-    Sandesh::InitGenerator("SandeshAsyncTest-Client", "localhost", evm_.get(),
+    Sandesh::InitGenerator("SandeshAsyncTest-Client", "localhost", 
+                           "Test", "Test", evm_.get(),
                            0);
     Sandesh::ConnectToCollector("127.0.0.1", port);
     Sandesh::SetLoggingParams(true, "", "UT_DEBUG");
@@ -388,7 +389,7 @@ TEST_F(SandeshRequestTest, Request) {
     ASSERT_LT(0, port);
     // Connect to the server
     Sandesh::InitGenerator("SandeshRequestTest-Client", "localhost",
-            evm_.get(), 0, NULL);
+            "Test", "Test", evm_.get(), 0, NULL);
     Sandesh::ConnectToCollector("127.0.0.1", port);
     TASK_UTIL_EXPECT_TRUE(Sandesh::client()->state() == SandeshClientSM::ESTABLISHED);
     // Send the request

--- a/library/cpp/test/sandesh_show_trace_test.cc
+++ b/library/cpp/test/sandesh_show_trace_test.cc
@@ -70,7 +70,8 @@ int main(int argc, char **argv) {
     EventManager evm;
     TaskScheduler *scheduler = TaskScheduler::GetInstance();
     int task_id = scheduler->GetTaskId("sandesh show trace test");
-    Sandesh::InitGeneratorTest("sandesh show trace test", "localhost", &evm, 0,
+    Sandesh::InitGeneratorTest("sandesh show trace test", "localhost", 
+            "sandesh show trace test", "sandesh show trace test", &evm, 0,
             NULL);
     Sandesh::SetLoggingParams(false, "", SandeshLevel::UT_DEBUG);
 

--- a/library/python/pysandesh/sandesh_base.py
+++ b/library/python/pysandesh/sandesh_base.py
@@ -37,6 +37,8 @@ class Sandesh(object):
         self._scope = ''
         self._module = ''
         self._source = ''
+        self._node_type = ''
+        self._instance_id = ''
         self._timestamp = 0
         self._versionsig = 0
         self._type = 0
@@ -52,12 +54,15 @@ class Sandesh(object):
 
     # Public functions
 
-    def init_generator(self, module, source, collectors, client_context,
+    def init_generator(self, module, source, node_type, instance_id,
+                       collectors, client_context, 
                        http_port, sandesh_req_uve_pkg_list=None,
                        discovery_client=None):
         self._role = self.SandeshRole.GENERATOR
         self._module = module
         self._source = source
+        self._node_type = node_type
+        self._instance_id = instance_id
         self._client_context = client_context
         self._collectors = collectors
         self._rcv_queue = WorkQueue(self._process_rx_sandesh)
@@ -168,6 +173,14 @@ class Sandesh(object):
     def source_id(self):
         return self._source
     # end source_id
+
+    def node_type(self):
+        return self._node_type
+    #end node_type
+
+    def instance_id(self):
+        return self._instance_id
+    #end instance_id
 
     def scope(self):
         return self._scope
@@ -286,9 +299,11 @@ class Sandesh(object):
                 self._client.connection().secondary_collector()
             if client_info.secondary is None:
                 client_info.secondary = ''
-            module_state = ModuleClientState(
-                name=self._source + ':' + self._module,
-                client_info=client_info)
+            module_state = ModuleClientState(name=self._source + ':' +
+                                             self._node_type + ':' + 
+                                             self._module + ':' +
+                                             self._instance_id, 
+                                             client_info=client_info)
             generator_info = SandeshModuleClientTrace(
                 data=module_state, sandesh=self)
             generator_info.send(sandesh=self)

--- a/library/python/pysandesh/sandesh_connection.py
+++ b/library/python/pysandesh/sandesh_connection.py
@@ -88,7 +88,9 @@ class SandeshConnection(object):
             uve_types.append(uve_type_key)
         from gen_py.sandesh_ctrl.ttypes import SandeshCtrlClientToServer
         ctrl_msg = SandeshCtrlClientToServer(self._sandesh_instance.source_id(),
-            self._sandesh_instance.module(), count, uve_types, os.getpid(), 0)
+            self._sandesh_instance.module(), count, uve_types, os.getpid(), 0,
+            self._sandesh_instance.node_type(), 
+            self._sandesh_instance.instance_id())
         self._logger.debug('Send sandesh control message. uve type count # %d' % (len(uve_types)))
         ctrl_msg.request('ctrl', sandesh=self._sandesh_instance)
     #end handle_initialized

--- a/library/python/pysandesh/sandesh_session.py
+++ b/library/python/pysandesh/sandesh_session.py
@@ -161,7 +161,9 @@ class SandeshWriter(object):
                                     sandesh.type(),
                                     sandesh.hints(),
                                     sandesh.level(),
-                                    sandesh.category())
+                                    sandesh.category(),
+                                    sandesh.node_type(),
+                                    sandesh.instance_id())
         # write the sandesh header
         if sandesh_hdr.write(protocol) < 0:
             print 'Error in encoding sandesh header'

--- a/library/python/pysandesh/sandesh_state_machine.py
+++ b/library/python/pysandesh/sandesh_state_machine.py
@@ -114,7 +114,7 @@ class SandeshStateMachine(object):
             e.sm._cancel_connect_timer()
             e.sm._connection.set_collector(e.sm_event.source)
             e.sm._connection.handle_sandesh_ctrl_msg(e.sm_event.msg)
-            self._connection.sandesh_instance().send_generator_info()
+            e.sm._connection.sandesh_instance().send_generator_info()
         #end _on_established
 
         # FSM - Fysom

--- a/library/python/pysandesh/test/sandesh_msg_test.py
+++ b/library/python/pysandesh/test/sandesh_msg_test.py
@@ -40,7 +40,7 @@ class SandeshMsgTest(unittest.TestCase):
     def setUpClass(cls):
         http_port = test_utils.get_free_port()
         sandesh_global.init_generator('sandesh_msg_test', socket.gethostname(), 
-                None, 'sandesh_msg_test_ctxt', http_port)
+                'Test', 'Test', None, 'sandesh_msg_test_ctxt', http_port)
 
     def setUp(self):
         self.setUpClass()

--- a/library/python/pysandesh/test/sandesh_session_test.py
+++ b/library/python/pysandesh/test/sandesh_session_test.py
@@ -72,7 +72,7 @@ class SandeshReaderTest(unittest.TestCase):
         if (not sandesh_test_started):
             http_port = test_utils.get_free_port()
             sandesh_global.init_generator('sandesh_session_test', 
-                socket.gethostname(), None,  
+                socket.gethostname(), 'Test', 'Test', None,  
                 'sandesh_msg_test_ctxt', http_port)
             sandesh_test_started = True
 

--- a/library/python/pysandesh/test/sandesh_trace_test.py
+++ b/library/python/pysandesh/test/sandesh_trace_test.py
@@ -23,7 +23,7 @@ class SandeshTraceTest(unittest.TestCase):
         self._sandesh = Sandesh()
         http_port = test_utils.get_free_port()
         self._sandesh.init_generator('sandesh_trace_test', socket.gethostname(),
-            None, 'trace_test_ctxt', http_port)
+            'Test', 'Test', None, 'trace_test_ctxt', http_port)
         self._trace_read_list = []
     #end setUp
 


### PR DESCRIPTION
1. Add instance id and node type support to generators and analytics to
   support multiple instances of process running on the same node
2. Remove all fields table
