### PR TITLE
Fix for #2267

### DIFF
--- a/library/python/pysandesh/sandesh_uve.py
+++ b/library/python/pysandesh/sandesh_uve.py
@@ -134,7 +134,8 @@ class SandeshUVEPerTypeMap(object):
             for uve_name, uve_entry in self._uve_map.iteritems():
                 if seqno == 0 or seqno < uve_entry.seqno:
                     try:
-                        sandesh_uve = getattr(imp_module, self._uve_type)()
+                        sandesh_uve = \
+                            getattr(imp_module, self._uve_type)(sandesh=sandesh_instance)
                     except AttributeError:
                         logger.error('Failed to create sandesh UVE "%s"' % (self._uve_type))
                         break


### PR DESCRIPTION
During UVE sync, the UVE object is initialized with the sandesh_global instance during creation.
If the sandesh client doesn't call init_generator() on the sandesh_global instance, then the sandesh_global
instance will have empty source, node_type, module and instance_id. Therefore, UVE object initialized with
the sandesh_global instance will be sent with empty source, node_type, module and instance_id in the sandesh header. This results in improper addition/updation/deletion of UVEs in redis.
In sync_uve(), pass sandesh_instance while creating UVE object.
