### PR TITLE
Patch in: 69c88b64701caaac414bbc753061dfd86094c518 missed commit

### DIFF
--- a/library/cpp/sandesh_state_machine.h
+++ b/library/cpp/sandesh_state_machine.h
@@ -125,13 +125,16 @@ public:
     }
 
     void set_last_event(const std::string &event) {
+        tbb::mutex::scoped_lock lock(smutex_);
         last_event_ = event;
         last_event_at_ = UTCTimestampUsec();
     }
-    const std::string &last_event() const {
+    const std::string last_event() const {
+        tbb::mutex::scoped_lock lock(smutex_);
         return last_event_;
     }
     void reset_last_info() {
+        tbb::mutex::scoped_lock lock(smutex_);
         last_state_ = ssm::IDLE;
         last_event_ = "";
     }
@@ -185,26 +188,9 @@ private:
     std::string last_event_;
     uint64_t last_event_at_;
 
-    struct EventStats {
-        EventStats() :
-            enqueues(0),
-            enqueue_fails(0),
-            dequeues(0),
-            dequeue_fails(0) {
-        }
-        uint64_t enqueues;
-        uint64_t enqueue_fails;
-        uint64_t dequeues;
-        uint64_t dequeue_fails;
-    };
-    typedef boost::ptr_map<std::string, EventStats> EventStatsMap;
-    EventStatsMap event_stats_;
-    uint64_t enqueues_;
-    uint64_t enqueue_fails_;
-    uint64_t dequeues_;
-    uint64_t dequeue_fails_;
-    tbb::mutex stats_mutex_;
     std::string generator_key_;
+    mutable tbb::mutex smutex_;
+    SandeshEventStatistics event_stats_;
     SandeshStatistics message_stats_;
             
     DISALLOW_COPY_AND_ASSIGN(SandeshStateMachine);

--- a/library/cpp/sandesh_statistics.h
+++ b/library/cpp/sandesh_statistics.h
@@ -14,12 +14,37 @@ public:
     void Update(const std::string& sandesh_name,
                 uint32_t bytes, bool is_tx, bool dropped);
     void Get(std::vector<SandeshMessageTypeStats> &mtype_stats,
-             SandeshMessageStats &magg_stats);
+             SandeshMessageStats &magg_stats) const;
     void Get(boost::ptr_map<std::string, SandeshMessageTypeStats> &mtype_stats,
-             SandeshMessageStats &magg_stats);
+             SandeshMessageStats &magg_stats) const;
 
     boost::ptr_map<std::string, SandeshMessageTypeStats> type_stats;
     SandeshMessageStats agg_stats;
 };
 
+struct EventStats {
+    EventStats() :
+        enqueues(0),
+        enqueue_fails(0),
+        dequeues(0),
+        dequeue_fails(0) {
+    }
+    uint64_t enqueues;
+    uint64_t enqueue_fails;
+    uint64_t dequeues;
+    uint64_t dequeue_fails;
+};
+
+class SandeshEventStatistics {
+public:
+    SandeshEventStatistics() {}
+
+    void Update(std::string &event_name, bool enqueue, bool fail);
+    void Get(std::vector<SandeshStateMachineEvStats> &ev_stats) const;
+
+    typedef boost::ptr_map<std::string, EventStats> EventStatsMap;
+    EventStatsMap event_stats;
+    EventStats agg_stats;
+};
+    
 #endif // __SANDESH_STATISTICS_H__


### PR DESCRIPTION
commit 69c88b64701caaac414bbc753061dfd86094c518
Author: Megh Bhatt meghb@juniper.net
Date:   Thu Dec 19 15:46:39 2013 -0800

```
1. Fix potential memory corruption caused by accessing and modifying
   last_event in SandeshStateMachine and SandeshClientSM from
   concurrent threads by using the state machine mutex.
2. Consolidate state machine event statistics into a common
   structure - SandeshEventStatistics - sandesh_statistics.h
   and let both SandeshStateMachine and SandeshClientSM use it.
```
