### PR TITLE
Do not log from static variable constructor, as the Logger would not have...

### DIFF
--- a/library/cpp/sandesh_uve.h
+++ b/library/cpp/sandesh_uve.h
@@ -32,7 +32,6 @@ public:
     typedef std::map<std::string, SandeshUVEPerTypeMap *> uve_global_map;
 
     static void RegisterType(const std::string &s, SandeshUVEPerTypeMap *tmap) {
-        LOG(DEBUG, __func__ << "Registering " << s);
         assert(GetMap()->insert(std::make_pair(s, tmap)).second);
     }
     static const SandeshUVEPerTypeMap * TypeMap(const std::string &s) {


### PR DESCRIPTION
These show up (unnecessarily) in various daemon starts that link with sandesh library due to logging calls via static variable initializations.

log4cplus:ERROR No appenders could be found for logger (root).
log4cplus:ERROR Please initialize the log4cplus system properly.
