### PR TITLE
Changes for flow message processing optimizations in collector:

### DIFF
--- a/library/c/test/SConscript
+++ b/library/c/test/SConscript
@@ -46,6 +46,7 @@ SandeshLibs = ['gunit',
                'xml2',
                'xslt',
                'task_test',
+               'pugixml',
                ]
 
 env.Append(LIBPATH = SandeshLibPath)

--- a/library/common/sandesh.sandesh
+++ b/library/common/sandesh.sandesh
@@ -58,7 +58,9 @@ enum SandeshLevel {
 
 const i32 SANDESH_KEY_HINT = 0x1
 const i32 SANDESH_CONTROL_HINT = 0x2
-    
+
+// Update ParseHeader function in sandesh_message_builder.cc
+// when modifying SandeshHeader below 
 struct SandeshHeader {
     1: string Namespace;
     2: i64 Timestamp;

--- a/library/cpp/SConscript
+++ b/library/cpp/SConscript
@@ -99,6 +99,7 @@ libsandesh = env.Library(target = 'sandesh',
                                    'sandesh_connection.cc',
                                    'sandesh_server.cc',
                                    'sandesh_uve.cc',
+                                   'sandesh_message_builder.cc',
                                    'protocol/TXMLProtocol.cpp',
                                    'transport/TFDTransport.cpp',
                                    'transport/TSimpleFileTransport.cpp',
@@ -121,6 +122,7 @@ env.Install(env['TOP_INCLUDE'] + '/sandesh', 'sandesh_state_machine.h')
 env.Install(env['TOP_INCLUDE'] + '/sandesh', 'sandesh_connection.h')
 env.Install(env['TOP_INCLUDE'] + '/sandesh', 'sandesh_statistics.h')
 env.Install(env['TOP_INCLUDE'] + '/sandesh', 'request_pipeline.h')
+env.Install(env['TOP_INCLUDE'] + '/sandesh', 'sandesh_message_builder.h')
 env.Install(env['TOP_INCLUDE'] + '/sandesh', SandeshGenHdrs)
 env.Install(env['TOP_INCLUDE'] + '/sandesh', SandeshTraceGenHdrs)
 env.Install(env['TOP_INCLUDE'] + '/sandesh/protocol', 'protocol/TProtocol.h')                                  

--- a/library/cpp/sandesh_client.cc
+++ b/library/cpp/sandesh_client.cc
@@ -164,11 +164,6 @@ bool SandeshClient::ReceiveMsg(const std::string& msg,
     namespace sandesh_prot = contrail::sandesh::protocol;
     namespace sandesh_trans = contrail::sandesh::transport;
 
-    if (header_offset == 0) {
-        Sandesh::UpdateSandeshStats(sandesh_name, msg.size(), false, true);
-        return false;
-    }
-
     if (header.get_Hints() & g_sandesh_constants.SANDESH_CONTROL_HINT) {
         bool success = ReceiveCtrlMsg(msg, header, sandesh_name, header_offset);
         Sandesh::UpdateSandeshStats(sandesh_name, msg.size(), false, !success);

--- a/library/cpp/sandesh_client_sm.cc
+++ b/library/cpp/sandesh_client_sm.cc
@@ -698,7 +698,13 @@ void SandeshClientSMImpl::OnMessage(SandeshSession *session,
     uint32_t xml_offset = 0;
 
     // Extract the header and message type
-    SandeshReader::ExtractMsgHeader(msg, header, message_type, xml_offset);
+    int ret = SandeshReader::ExtractMsgHeader(msg, header, message_type,
+        xml_offset);
+    if (ret) {
+        SM_LOG(ERROR, "OnMessage in state: " << StateName() << ": Extract "
+               << " FAILED(" << ret << ")");
+        return;
+    }
     
     if (header.get_Hints() & g_sandesh_constants.SANDESH_CONTROL_HINT) {
         SM_LOG(INFO, "OnMessage control in state: " << StateName() );

--- a/library/cpp/sandesh_connection.cc
+++ b/library/cpp/sandesh_connection.cc
@@ -179,10 +179,6 @@ bool SandeshServerConnection::ProcessSandeshCtrlMessage(const std::string &msg,
         CONNECTION_LOG(ERROR, __func__ << " No Server");
         return false;
     }
-    if (header_offset == 0) {
-        CONNECTION_LOG(ERROR, __func__ << " No Sandesh Header");
-        return false;
-    }
     Sandesh *ctrl_snh = SandeshSession::DecodeCtrlSandesh(msg, header, sandesh_name,
                                                           header_offset);
     bool ret = sserver->ReceiveSandeshCtrlMsg(state_machine(), session(), ctrl_snh);
@@ -199,28 +195,14 @@ bool SandeshServerConnection::ProcessResourceUpdate(bool rsc) {
     return sserver->ReceiveResourceUpdate(session(), rsc);
 }
 
-bool SandeshServerConnection::ProcessSandeshMessage(const std::string &msg,
-        const SandeshHeader &header, const std::string sandesh_name,
-        const uint32_t header_offset, bool resource) {
+bool SandeshServerConnection::ProcessSandeshMessage(
+        const SandeshMessage *msg, bool resource) {
     SandeshServer *sserver = dynamic_cast<SandeshServer *>(server());
     if (!sserver) {
         CONNECTION_LOG(ERROR, __func__ << " No Server");
         return false;
     }
-    if (header_offset == 0) {
-        CONNECTION_LOG(ERROR, __func__ << " No Sandesh Header");
-        return false;
-    }
-    sserver->ReceiveSandeshMsg(session(), msg, sandesh_name, header, header_offset, resource);
-    return true;
-}
-
-bool SandeshServerConnection::ProcessMessage(ssm::Message *msg) {
-    SandeshServer *sserver = dynamic_cast<SandeshServer *>(server());
-    if (!sserver) {
-        CONNECTION_LOG(ERROR, __func__ << " No Server");
-        return false;
-    }
+    sserver->ReceiveSandeshMsg(session(), msg, resource);
     return true;
 }
 

--- a/library/cpp/sandesh_connection.h
+++ b/library/cpp/sandesh_connection.h
@@ -23,6 +23,7 @@ class TcpSession;
 class TcpServer;
 class SandeshUVE;
 class SandeshHeader;
+class SandeshMessage;
 
 class SandeshConnection {
 public:
@@ -67,13 +68,11 @@ public:
     void SetAdminState(bool down);
 
     virtual bool ProcessResourceUpdate(bool res) { return true; }
-    virtual bool ProcessSandeshMessage(const std::string &msg,
-            const SandeshHeader &header, const std::string sandesh_name,
-            const uint32_t header_offset, bool resource) = 0;
+    virtual bool ProcessSandeshMessage(const SandeshMessage *msg,
+            bool resource) = 0;
     virtual bool ProcessSandeshCtrlMessage(const std::string &msg,
             const SandeshHeader &header, const std::string sandesh_name,
             const uint32_t header_offset) = 0;
-    virtual bool ProcessMessage(ssm::Message *msg) = 0;
     virtual void ProcessDisconnect(SandeshSession * sess) = 0;
 
     virtual void ManagedDelete() = 0;
@@ -105,13 +104,11 @@ public:
     virtual ~SandeshServerConnection();
 
     virtual bool ProcessResourceUpdate(bool res); 
-    virtual bool ProcessSandeshMessage(const std::string &msg,
-            const SandeshHeader &header, const std::string sandesh_name,
-            const uint32_t header_offset, bool resource);
+    virtual bool ProcessSandeshMessage(const SandeshMessage *msg,
+            bool resource);
     virtual bool ProcessSandeshCtrlMessage(const std::string &msg,
             const SandeshHeader &header, const std::string sandesh_name,
-            const uint32_t header_offset);
-    virtual bool ProcessMessage(ssm::Message *msg);
+            const uint32_t header_offset);    
     virtual void ProcessDisconnect(SandeshSession *session);
 
     virtual void ManagedDelete();

--- a/library/cpp/sandesh_message_builder.cc
+++ b/library/cpp/sandesh_message_builder.cc
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#include <base/logging.h>
+#include <sandesh/sandesh_message_builder.h>
+
+using namespace pugi;
+using namespace std;
+
+// SandeshMessage
+SandeshMessage::~SandeshMessage() {
+}
+
+static bool ParseInteger(const pugi::xml_node &node, int *valuep) {
+    char *endp;
+    *valuep = strtoul(node.child_value(), &endp, 10);
+    return endp[0] == '\0';
+}
+
+static bool ParseUnsignedLong(const pugi::xml_node &node, uint64_t *valuep) {
+    char *endp;
+    *valuep = strtoull(node.child_value(), &endp, 10);
+    return endp[0] == '\0';
+}
+
+// SandeshXMLMessage
+SandeshXMLMessage::~SandeshXMLMessage() {
+}
+
+bool SandeshXMLMessage::ParseHeader(const xml_node& root,
+    SandeshHeader& header) {
+    for (xml_node node = root.first_child(); node;
+         node = node.next_sibling()) {
+        const char *name(node.name());
+        assert(strcmp(node.last_attribute().name(), "identifier") == 0);
+        int identifier(node.last_attribute().as_int());
+        switch (identifier) {
+        case 1:
+            header.set_Namespace(node.child_value());
+            break;
+        case 2:
+            uint64_t Timestamp;
+            if (!ParseUnsignedLong(node, &Timestamp)) return false;
+            header.set_Timestamp(Timestamp);
+            break;
+        case 3:
+            header.set_Module(node.child_value());
+            break;
+        case 4:
+            header.set_Source(node.child_value());
+            break;
+        case 5:
+            header.set_Context(node.child_value());
+            break;
+        case 6:
+            int SequenceNum;
+            if (!ParseInteger(node, &SequenceNum)) return false;
+            header.set_SequenceNum(SequenceNum);
+            break;
+        case 7:
+            int VersionSig;
+            if (!ParseInteger(node, &VersionSig)) return false;
+            header.set_VersionSig(VersionSig);
+            break;
+        case 8:
+            int Type;
+            if (!ParseInteger(node, &Type)) return false;
+            header.set_Type(static_cast<SandeshType::type>(Type));
+            break;
+        case 9:
+            int Hints;
+            if (!ParseInteger(node, &Hints)) return false;
+            header.set_Hints(Hints);
+            break;
+        case 10:
+            int Level;
+            if (!ParseInteger(node, &Level)) return false;
+            header.set_Level(static_cast<SandeshLevel::type>(Level));
+            break;
+        case 11:
+            header.set_Category(node.child_value());
+            break;
+        case 12:
+            header.set_NodeType(node.child_value());
+            break;
+        case 13:
+            header.set_InstanceId(node.child_value());
+            break;
+        case 14:
+            header.set_IPAddress(node.child_value());
+            break;
+        case 15:
+            int Pid;
+            if (!ParseInteger(node, &Pid)) return false;
+            header.set_Pid(Pid);
+            break;
+        default:
+            LOG(ERROR, __func__ << ": Unknown identifier: " << identifier);
+            break;
+        }
+    }
+    return true;
+}
+
+bool SandeshXMLMessage::Parse(const uint8_t *xml_msg, size_t size) {
+    xml_parse_result result = xdoc_.load_buffer(xml_msg, size,
+        parse_default & ~parse_escapes);
+    if (!result) {
+        LOG(ERROR, __func__ << ": Unable to load Sandesh XML. (status=" <<
+            result.status << ", offset=" << result.offset << "): " << 
+            xml_msg);
+        return false;
+    }
+    xml_node header_node = xdoc_.first_child();
+    if (!ParseHeader(header_node, header_)) {
+        LOG(ERROR, __func__ << ": Sandesh header parse FAILED: " << 
+            xml_msg);
+        return EINVAL;
+    }
+    message_node_ = header_node.next_sibling();
+    message_type_ = message_node_.name();
+    size_ = size;
+}
+
+const std::string SandeshXMLMessage::ExtractMessage() const {
+    ostringstream sstream;
+    message_node_.print(sstream, "", format_raw | format_no_declaration | 
+        format_no_escapes);
+    return sstream.str();
+}
+
+// SandeshSyslogMessage
+SandeshSyslogMessage::~SandeshSyslogMessage() {
+}
+
+bool SandeshSyslogMessage::Parse(const uint8_t *xml_msg, size_t size) {
+    xml_parse_result result = xdoc_.load_buffer(xml_msg, size,
+        parse_default & ~parse_escapes);
+    if (!result) {
+        LOG(ERROR, __func__ << ": Unable to load Sandesh Syslog. (status=" <<
+            result.status << ", offset=" << result.offset << "): " <<
+            xml_msg);
+        return false;
+    }
+    message_node_ = xdoc_.first_child();
+    message_type_ = message_node_.name();
+    size_ = size;
+}
+
+// SandeshMessageBuilder
+SandeshMessageBuilder *SandeshMessageBuilder::GetInstance(
+    SandeshMessageBuilder::Type type) {
+    if (type == SandeshMessageBuilder::XML) {
+        return SandeshXMLMessageBuilder::GetInstance();
+    } else if (type == SandeshMessageBuilder::SYSLOG) {
+        return SandeshSyslogMessageBuilder::GetInstance();
+    }
+    return NULL;
+}
+
+// SandeshXMLMessageBuilder
+SandeshMessage *SandeshXMLMessageBuilder::Create(
+    const uint8_t *xml_msg, size_t size) const {
+    SandeshXMLMessage *msg = new SandeshXMLMessage;
+    msg->Parse(xml_msg, size);
+    return msg;
+}
+
+SandeshXMLMessageBuilder SandeshXMLMessageBuilder::instance_;
+
+SandeshXMLMessageBuilder::SandeshXMLMessageBuilder() {
+}
+
+SandeshXMLMessageBuilder *SandeshXMLMessageBuilder::GetInstance() {
+    return &instance_;
+}
+
+// SandeshSyslogMessageBuilder
+SandeshMessage *SandeshSyslogMessageBuilder::Create(
+    const uint8_t *xml_msg, size_t size) const {
+    SandeshSyslogMessage *msg = new SandeshSyslogMessage;
+    msg->Parse(xml_msg, size);
+    return msg;
+}
+
+SandeshSyslogMessageBuilder SandeshSyslogMessageBuilder::instance_;
+
+SandeshSyslogMessageBuilder::SandeshSyslogMessageBuilder() {
+}
+
+SandeshSyslogMessageBuilder *SandeshSyslogMessageBuilder::GetInstance() {
+    return &instance_;
+}

--- a/library/cpp/sandesh_message_builder.h
+++ b/library/cpp/sandesh_message_builder.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#ifndef __SANDESH_MESSAGE_BUILDER_H__
+#define __SANDESH_MESSAGE_BUILDER_H__
+
+#include <pugixml/pugixml.hpp>
+
+#include <sandesh/sandesh_types.h>
+#include <sandesh/sandesh.h>
+
+class SandeshMessage {
+public:
+    SandeshMessage() :
+        size_(0) {
+    }
+    virtual ~SandeshMessage();
+    virtual bool Parse(const uint8_t *data, size_t size) = 0;
+    virtual const std::string ExtractMessage() const = 0;
+    const SandeshHeader& GetHeader() const { return header_; }
+    const std::string& GetMessageType() const { return message_type_; }
+    const size_t GetSize() const { return size_; }
+ 
+protected:
+    SandeshHeader header_;
+    std::string message_type_;
+    size_t size_;
+};
+
+class SandeshXMLMessage : public SandeshMessage {
+public:
+    SandeshXMLMessage() {}
+    virtual ~SandeshXMLMessage();
+    virtual bool Parse(const uint8_t *data, size_t size);
+    virtual const std::string ExtractMessage() const;
+    const pugi::xml_node& GetMessageNode() const { return message_node_; }
+
+protected:
+    bool ParseHeader(const pugi::xml_node& root,
+        SandeshHeader& header);
+
+    pugi::xml_document xdoc_;
+    pugi::xml_node message_node_;
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(SandeshXMLMessage);
+};
+
+class SandeshSyslogMessage : public SandeshXMLMessage {
+public:
+    SandeshSyslogMessage() {}
+    virtual ~SandeshSyslogMessage();
+    virtual bool Parse(const uint8_t *data, size_t size);
+    void SetHeader(const SandeshHeader &header) { header_ = header; }
+
+private:
+    DISALLOW_COPY_AND_ASSIGN(SandeshSyslogMessage);
+};
+    
+class SandeshMessageBuilder {
+public:
+    enum Type {
+        XML,
+        SYSLOG,
+    };
+    virtual SandeshMessage *Create(const uint8_t *data, size_t size) const = 0;
+    static SandeshMessageBuilder *GetInstance(Type type);
+};
+
+class SandeshXMLMessageBuilder : public SandeshMessageBuilder {
+public:
+    SandeshXMLMessageBuilder();
+    virtual SandeshMessage *Create(const uint8_t *data, size_t size) const;
+    static SandeshXMLMessageBuilder *GetInstance();
+
+private:
+    static SandeshXMLMessageBuilder instance_;
+    DISALLOW_COPY_AND_ASSIGN(SandeshXMLMessageBuilder);
+};
+
+class SandeshSyslogMessageBuilder : public SandeshMessageBuilder {
+public:
+    SandeshSyslogMessageBuilder();
+    virtual SandeshMessage *Create(const uint8_t *data, size_t size) const;
+    static SandeshSyslogMessageBuilder *GetInstance();
+
+private:
+    static SandeshSyslogMessageBuilder instance_;
+    DISALLOW_COPY_AND_ASSIGN(SandeshSyslogMessageBuilder);
+};
+
+#endif // __SANDESH_MESSAGE_BUILDER_H__

--- a/library/cpp/sandesh_server.h
+++ b/library/cpp/sandesh_server.h
@@ -26,10 +26,7 @@ class SandeshSession;
 class SandeshStateMachine;
 class LifetimeActor;
 class LifetimeManager;
-
-namespace ssm {
-    struct Message;
-}
+class SandeshMessage;
 
 class SandeshServer : public TcpServer {
 public:
@@ -53,8 +50,7 @@ public:
     virtual bool ReceiveResourceUpdate(SandeshSession *session,
             bool rsc) { return true; } 
     virtual bool ReceiveSandeshMsg(SandeshSession *session,
-        const std::string& cmsg, const std::string& message_type,
-        const SandeshHeader& header, uint32_t xml_offset, bool resource) = 0;
+        const SandeshMessage *msg, bool resource) = 0;
     virtual bool ReceiveSandeshCtrlMsg(SandeshStateMachine *state_machine,
             SandeshSession *session, const Sandesh *sandesh);
     virtual void DisconnectSession(SandeshSession *session) {}

--- a/library/cpp/sandesh_session.cc
+++ b/library/cpp/sandesh_session.cc
@@ -414,14 +414,14 @@ int SandeshReader::ExtractMsgHeader(const std::string& msg,
     boost::shared_ptr<TXMLProtocol> prot =
             boost::shared_ptr<TXMLProtocol>(new TXMLProtocol(btrans));
     // Read the sandesh header and note the offset
-    if ((ret = header.read(prot)) < 0) {
+    if ((ret = header.read(prot)) <= 0) {
         LOG(ERROR, __func__ << ": Sandesh header read FAILED: " << msg);
         return EINVAL;
     }
     xfer += ret;
     header_offset = xfer;
     // Extract the message name
-    if ((ret = prot->readSandeshBegin(msg_type)) < 0) {
+    if ((ret = prot->readSandeshBegin(msg_type)) <= 0) {
         LOG(ERROR, __func__ << ": Sandesh begin read FAILED: " << msg);
         return EINVAL;
     }

--- a/library/cpp/sandesh_state_machine.h
+++ b/library/cpp/sandesh_state_machine.h
@@ -40,11 +40,6 @@ typedef enum {
     SERVER_INIT = 3,
 } SsmState;
 
-struct Message {
-    virtual ~Message() {}
-protected:
-    Message() {}
-};
 } // namespace ssm
 
 class SandeshSession;
@@ -55,6 +50,7 @@ class SandeshUVE;
 class SandeshStateMachineStats;
 class SandeshGeneratorStats;
 class SandeshStatistics;
+class SandeshMessageBuilder;
 
 typedef boost::function<bool(SandeshStateMachine *)> EvValidate;
 
@@ -192,6 +188,7 @@ private:
     mutable tbb::mutex smutex_;
     SandeshEventStatistics event_stats_;
     SandeshStatistics message_stats_;
+    SandeshMessageBuilder *builder_;
             
     DISALLOW_COPY_AND_ASSIGN(SandeshStateMachine);
 };

--- a/library/cpp/test/SConscript
+++ b/library/cpp/test/SConscript
@@ -57,6 +57,7 @@ SandeshLibs = ['gunit',
                'xml2',
                'xslt',
                'task_test',
+               'pugixml',
                ]
 
 env.Append(LIBPATH = SandeshLibPath)

--- a/library/cpp/test/sandesh_session_test.cc
+++ b/library/cpp/test/sandesh_session_test.cc
@@ -160,12 +160,7 @@ public:
     }
 
     virtual bool ReceiveSandeshMsg(SandeshSession *session,
-                           const string& cmsg, const string& message_type,
-                           const SandeshHeader& header, uint32_t xml_offset, bool rsc) {
-        return true;
-    }
-
-    virtual bool ReceiveMsg(SandeshSession *session, ssm::Message *msg) {
+         const SandeshMessage *msg, bool rsc) {
         return true;
     }
 };

--- a/library/cpp/test/sandesh_state_machine_test.cc
+++ b/library/cpp/test/sandesh_state_machine_test.cc
@@ -114,12 +114,7 @@ public:
     }
 
     virtual bool ReceiveSandeshMsg(SandeshSession *session,
-       const string& cmsg, const string& message_type,
-       const SandeshHeader& header, uint32_t xml_offset, bool rsc) {
-        return true;
-    }
-
-    virtual bool ReceiveMsg(SandeshSession *session, ssm::Message *msg) {
+       const SandeshMessage *msg, bool rsc) {
         return true;
     }
 


### PR DESCRIPTION
1. Rewrite FlowTableInsert to traverse the flow message XML
   tree only once and extract the needed fields into an
   array. Use the array to populate the vectors needed to
   populate the FlowRecordTable and the flow index tables.
2. Use the DbDataValueType type to encode the value into
   string rather than using the column family name to determine
   the type. This avoid 2 map lookups per field encoded.
   Add a boost::blank as the first element of DbDataValueType
   variant instead of std::string to determine if the variant
   is populated or not.
3. Add a mock_generator in C++ which sends flow messages and
   can be used to scale test vizd.
4. Use pugixml to decode the SandeshHeader and the sandesh
   message in SandeshServer. Abstract out SandeshMessage
   creation and parsing using SandeshMessageBuilder, change
   vizd to use SandeshMessage.

With the above changes, we are able to increase vizd flow sandesh message
receive performance for 1 generator from around 1.5K msg/sec to
around 3.5K msg/sec using vizd built using compiler optimizations enabled -03
on single box setup - a6s23 - 4 core i3.
