### PR TITLE
We have some vizd cores in the State Machine Stats Update code.

### DIFF
--- a/library/cpp/sandesh_server.cc
+++ b/library/cpp/sandesh_server.cc
@@ -56,9 +56,10 @@ SandeshServer::SandeshServer(EventManager *evm)
     // 1. State machine and lifetime mgr since state machine delete happens
     //    in lifetime mgr task
     if (!task_policy_set_) {
-        TaskPolicy sm_task_policy = boost::assign::list_of
-                (TaskExclusion(lifetime_mgr_task_id_));
-        TaskScheduler::GetInstance()->SetPolicy(sm_task_id_, sm_task_policy);
+        TaskPolicy lm_task_policy = boost::assign::list_of
+                (TaskExclusion(sm_task_id_))
+                (TaskExclusion(session_reader_task_id_));
+        TaskScheduler::GetInstance()->SetPolicy(lifetime_mgr_task_id_, lm_task_policy);
         task_policy_set_ = true;
     }
 }


### PR DESCRIPTION
On these machines, redis was down and this was causing continuous
reconnection of generators.
It seems that the generator state machines were deleted (by the lifetime actor task)
while sandesh receive was being processed (by the sandesh state machine task)

The solution is to set task policies and make these tasks exclusive.
