### PR TITLE
1. Add watermarks for SandeshStateMachine work queue to prevent

### DIFF
--- a/library/cpp/sandesh_client.cc
+++ b/library/cpp/sandesh_client.cc
@@ -43,7 +43,7 @@ const std::string SandeshClient::kSMTask = "sandesh::SandeshClientSM";
 const std::string SandeshClient::kSessionWriterTask = "sandesh::SandeshClientSession";
 const std::string SandeshClient::kSessionReaderTask = "io::ReaderTask";
 bool SandeshClient::task_policy_set_ = false;
-const std::vector<SandeshSession::SessionWaterMarkInfo> 
+const std::vector<Sandesh::QueueWaterMarkInfo> 
     SandeshClient::kSessionWaterMarkInfo = boost::assign::tuple_list_of
 					       (50000, SandeshLevel::SYS_ERR, true)
                                                (10000, SandeshLevel::SYS_DEBUG, true)
@@ -295,7 +295,7 @@ void SandeshClient::SendUVE(int count,
 }
 
 void SandeshClient::SetSessionWaterMarkInfo(
-    SandeshSession::SessionWaterMarkInfo &scwm) {
+    Sandesh::QueueWaterMarkInfo &scwm) {
     SandeshSession *session = sm_->session();
     if (session) {
         session->SetSendQueueWaterMark(scwm);
@@ -312,7 +312,7 @@ void SandeshClient::ResetSessionWaterMarkInfo() {
 }    
 
 void SandeshClient::GetSessionWaterMarkInfo(
-    std::vector<SandeshSession::SessionWaterMarkInfo> &scwm_info) const {
+    std::vector<Sandesh::QueueWaterMarkInfo> &scwm_info) const {
     scwm_info = session_wm_info_;
 }
 

--- a/library/cpp/sandesh_client.h
+++ b/library/cpp/sandesh_client.h
@@ -82,10 +82,10 @@ public:
         return sm_->session();
     }
 
-    void SetSessionWaterMarkInfo(SandeshSession::SessionWaterMarkInfo &scwm);
+    void SetSessionWaterMarkInfo(Sandesh::QueueWaterMarkInfo &scwm);
     void ResetSessionWaterMarkInfo();
     void GetSessionWaterMarkInfo(
-        std::vector<SandeshSession::SessionWaterMarkInfo> &scwm_info) const;
+        std::vector<Sandesh::QueueWaterMarkInfo> &scwm_info) const;
 
     friend class CollectorInfoRequest;
 protected:
@@ -97,7 +97,7 @@ private:
     static const int kSessionTaskInstance = Task::kTaskInstanceAny;
     static const std::string kSessionWriterTask;
     static const std::string kSessionReaderTask;
-    static const std::vector<SandeshSession::SessionWaterMarkInfo> kSessionWaterMarkInfo;
+    static const std::vector<Sandesh::QueueWaterMarkInfo> kSessionWaterMarkInfo;
 
     int sm_task_instance_;
     int sm_task_id_;
@@ -107,7 +107,7 @@ private:
     Endpoint primary_, secondary_;
     Sandesh::CollectorSubFn csf_;
     boost::scoped_ptr<SandeshClientSM> sm_;
-    std::vector<SandeshSession::SessionWaterMarkInfo> session_wm_info_;
+    std::vector<Sandesh::QueueWaterMarkInfo> session_wm_info_;
     static bool task_policy_set_;
 
     void CollectorHandler(std::vector<DSResponse> resp);

--- a/library/cpp/sandesh_connection.cc
+++ b/library/cpp/sandesh_connection.cc
@@ -86,16 +86,6 @@ bool SandeshConnection::SendSandesh(Sandesh *snh) {
     return true;
 }
 
-SandeshSession *SandeshConnection::CreateSession() {
-    TcpSession *session = server_->CreateSession();
-    SandeshSession *sandesh_session =
-            static_cast<SandeshSession *>(session);
-    sandesh_session->SetReceiveMsgCb(
-            boost::bind(&SandeshConnection::ReceiveMsg, this, _1, _2));
-    sandesh_session->SetConnection(this);
-    return sandesh_session;
-}
-
 void SandeshConnection::AcceptSession(SandeshSession *session) {
     session->SetReceiveMsgCb(boost::bind(&SandeshConnection::ReceiveMsg, this, _1, _2));
     session->SetConnection(this);

--- a/library/cpp/sandesh_connection.h
+++ b/library/cpp/sandesh_connection.h
@@ -37,7 +37,6 @@ public:
     virtual void ReceiveMsg(const std::string &msg, SandeshSession *session);
 
     TcpServer *server() { return server_; }
-    SandeshSession *CreateSession();
 
     Endpoint endpoint() { return endpoint_; }
     bool SendSandesh(Sandesh *snh);

--- a/library/cpp/sandesh_req.cc
+++ b/library/cpp/sandesh_req.cc
@@ -115,13 +115,13 @@ void CollectorInfoRequest::HandleRequest() const {
 }
 
 void Sandesh::SendingParamsResponse(std::string context) {
-    std::vector<SandeshSession::SessionWaterMarkInfo> scwm_info;
+    std::vector<Sandesh::QueueWaterMarkInfo> scwm_info;
     std::vector<SandeshSendingParams> ssp_info;
     SandeshClient *client(Sandesh::client());
     if (client) {
         client->GetSessionWaterMarkInfo(scwm_info);
         for (size_t i = 0; i < scwm_info.size(); i++) {
-            SandeshSession::SessionWaterMarkInfo &scwm(scwm_info[i]);
+            Sandesh::QueueWaterMarkInfo &scwm(scwm_info[i]);
             SandeshSendingParams ssp;
             ssp.set_queue_count(boost::get<0>(scwm));
             SandeshLevel::type level(boost::get<1>(scwm));
@@ -148,7 +148,7 @@ void SandeshSendingParamsSet::HandleRequest() const {
         bool high(get_high());
         std::string slevel(get_level());
         SandeshLevel::type level(Sandesh::StringToLevel(slevel));
-        SandeshSession::SessionWaterMarkInfo scwm(qcount, level, high);
+        Sandesh::QueueWaterMarkInfo scwm(qcount, level, high);
         client->SetSessionWaterMarkInfo(scwm);
     }
     // Send response

--- a/library/cpp/sandesh_session.cc
+++ b/library/cpp/sandesh_session.cc
@@ -291,7 +291,7 @@ SandeshSession::SandeshSession(TcpServer *client, Socket *socket,
     keepalive_interval_(kSessionKeepaliveInterval),
     keepalive_probes_(kSessionKeepaliveProbes),
     reader_task_id_(reader_task_id) {
-    if (Sandesh::role() == Sandesh::Collector) {
+    if (Sandesh::role() == Sandesh::SandeshRole::Collector) {
         send_buffer_queue_.reset(new Sandesh::SandeshBufferQueue(writer_task_id,
                 task_instance,
                 boost::bind(&SandeshSession::SendBuffer, this, _1)));
@@ -309,7 +309,7 @@ bool SandeshSession::SessionSendReady() {
 }
 
 void SandeshSession::SetSendQueueWaterMark(
-    SandeshSession::SessionWaterMarkInfo &swmi) {
+    Sandesh::QueueWaterMarkInfo &swmi) {
     Sandesh::SandeshQueue::WaterMarkInfo wm(boost::get<0>(swmi),
         boost::bind(&Sandesh::SetSendingLevel, _1, boost::get<1>(swmi)));
     if (boost::get<2>(swmi)) {
@@ -325,7 +325,7 @@ void SandeshSession::ResetSendQueueWaterMark() {
 }
 
 void SandeshSession::Shutdown() {
-    if (Sandesh::role() == Sandesh::Collector) {
+    if (Sandesh::role() == Sandesh::SandeshRole::Collector) {
         send_buffer_queue_->Shutdown();
     }
     send_queue_->Shutdown();

--- a/library/cpp/sandesh_session.h
+++ b/library/cpp/sandesh_session.h
@@ -135,7 +135,6 @@ class SandeshConnection;
 
 class SandeshSession : public TcpSession {
 public:
-    typedef boost::tuple<size_t, SandeshLevel::type, bool> SessionWaterMarkInfo;
     typedef boost::function<void(const std::string&, SandeshSession *)> ReceiveMsgCb;
     SandeshSession(TcpServer *client, Socket *socket, int task_instance, 
         int writer_task_id, int reader_task_id);
@@ -210,7 +209,7 @@ public:
     const SandeshSessionStats& GetStats() const {
         return sstats_;
     }
-    void SetSendQueueWaterMark(SessionWaterMarkInfo &wm_info);
+    void SetSendQueueWaterMark(Sandesh::QueueWaterMarkInfo &wm_info);
     void ResetSendQueueWaterMark();
 
 protected:

--- a/library/cpp/sandesh_state_machine.h
+++ b/library/cpp/sandesh_state_machine.h
@@ -145,7 +145,10 @@ public:
     const std::string &generator_key() const {
         return generator_key_;
     }
+    void SetQueueWaterMarkInfo(Sandesh::QueueWaterMarkInfo &wm);
+    void ResetQueueWaterMarkInfo();
     bool GetQueueCount(uint64_t &queue_count) const;
+    bool GetMessageDropLevel(std::string &drop_level) const;
     bool GetStatistics(SandeshStateMachineStats &stats, 
                        SandeshGeneratorStats &msg_stats);
 
@@ -162,16 +165,19 @@ private:
     bool IdleHoldTimerExpired();
 
     template <typename Ev> void Enqueue(const Ev &event);
-    bool DequeueEvent(EventContainer ec);
+    bool DequeueEvent(EventContainer &ec);
     bool LogEvent(const sc::event_base *event);
     void UpdateEventDequeue(const sc::event_base &event);
     void UpdateEventDequeueFail(const sc::event_base &event);
     void UpdateEventEnqueue(const sc::event_base &event);
     void UpdateEventEnqueueFail(const sc::event_base &event);
     void UpdateEventStats(const sc::event_base &event, bool enqueue, bool fail);
+    void SetSandeshMessageDropLevel(size_t queue_count,
+        SandeshLevel::type level);
 
     const char *prefix_;
-    WorkQueue<EventContainer> work_queue_;
+    typedef WorkQueue<EventContainer> EventQueue;
+    EventQueue work_queue_;
     SandeshConnection *connection_;
     SandeshSession *session_;
     Timer *idle_hold_timer_;
@@ -189,6 +195,7 @@ private:
     SandeshEventStatistics event_stats_;
     SandeshStatistics message_stats_;
     SandeshMessageBuilder *builder_;
+    SandeshLevel::type message_drop_level_;
             
     DISALLOW_COPY_AND_ASSIGN(SandeshStateMachine);
 };

--- a/library/cpp/test/sandesh_trace_test.cc
+++ b/library/cpp/test/sandesh_trace_test.cc
@@ -401,11 +401,11 @@ class SandeshTracePerfTest : public ::testing::Test {
 protected:
     virtual void SetUp() {
         // Disable printing of trace
-        Sandesh::role_ = Sandesh::SandeshGenerator;
+        Sandesh::role_ = Sandesh::SandeshRole::Generator;
     }
 
     virtual void TearDown() {
-        Sandesh::role_ = Sandesh::Invalid;
+        Sandesh::role_ = Sandesh::SandeshRole::Invalid;
     }
 };
 


### PR DESCRIPTION
   vizd running out of memory
2. Scope SandeshRole enum to prevent clash with classes Generator
   and Collector in vizd
