### PR TITLE
After a recent change, Sandesh messages are encoded by sandesh code, but...

### DIFF
--- a/library/cpp/protocol/TXMLProtocol.cpp
+++ b/library/cpp/protocol/TXMLProtocol.cpp
@@ -609,7 +609,6 @@ int32_t TXMLProtocol::writeString(const string& str) {
   for (string::const_iterator it = str.begin(); it != str.end(); ++it) {
     switch(*it) {
     case '&':  xmlstr << "&amp;";  break;
-    case '\"': xmlstr << "&quot;";  break;
     case '\'': xmlstr << "&apos;"; break;          
     case '<':  xmlstr << "&lt;";   break;         
     case '>':  xmlstr << "&gt;";   break;
@@ -1091,7 +1090,6 @@ int32_t TXMLProtocol::readDouble(double& dub) {
 int32_t TXMLProtocol::readString(std::string &str) {
   readXMLString(str);
   boost::replace_all(str, "&amp;", "&");
-  boost::replace_all(str, "&quot;", "\"");
   boost::replace_all(str, "&apos;", "\'");
   boost::replace_all(str, "&lt;", "<");
   boost::replace_all(str, "&gt;", ">");

--- a/library/python/pysandesh/protocol/TXMLProtocol.py
+++ b/library/python/pysandesh/protocol/TXMLProtocol.py
@@ -264,7 +264,6 @@ class TXMLProtocol(TProtocolBase):
     match = re.search('<|>|&|\'|\"', string)
     if match is not None:
       string = string.replace('&', '&amp;')
-      string = string.replace('"', '&quot;')
       string = string.replace("'", '&apos;')
       string = string.replace('<', '&lt;')
       string = string.replace('>', '&gt;')
@@ -763,7 +762,6 @@ class TXMLProtocol(TProtocolBase):
     if string is None:
       return (-1, None)
     string = string.replace('&amp;', '&')
-    string = string.replace('&quot;', '"')
     string = string.replace('&apos;', "'")
     string = string.replace('&lt;', '<')
     string = string.replace('&gt;', '>')


### PR DESCRIPTION
... decoded by pugixml. Since pugixml does not expect escaping of quotes, we need to remove it in sandesh
