### PR TITLE
In cases when 2 generator connects are received, we disconnect

### DIFF
--- a/library/cpp/sandesh_state_machine.cc
+++ b/library/cpp/sandesh_state_machine.cc
@@ -442,7 +442,6 @@ void SandeshStateMachine::SetAdminState(bool down) {
 
 // Note this api does not enqueue the deletion of TCP session
 void SandeshStateMachine::clear_session() {
-    tbb::mutex::scoped_lock lock(mutex_);
     if (session_ != NULL) {
         session_->set_observer(NULL);
         session_->SetReceiveMsgCb(NULL);
@@ -455,7 +454,6 @@ void SandeshStateMachine::clear_session() {
 }
 
 void SandeshStateMachine::set_session(SandeshSession *session) {
-    tbb::mutex::scoped_lock lock(mutex_);
     if (session_ != NULL) {
         DeleteSession(session_);
     }
@@ -473,7 +471,6 @@ void SandeshStateMachine::DeleteSession(SandeshSession *session) {
 }
 
 SandeshSession *SandeshStateMachine::session() {
-    tbb::mutex::scoped_lock lock(mutex_);
     return session_;
 }
 

--- a/library/cpp/sandesh_state_machine.h
+++ b/library/cpp/sandesh_state_machine.h
@@ -180,7 +180,6 @@ private:
     EventQueue work_queue_;
     SandeshConnection *connection_;
     SandeshSession *session_;
-    mutable tbb::mutex mutex_;
     Timer *idle_hold_timer_;
     int idle_hold_time_;
     bool deleted_;


### PR DESCRIPTION
both sessions by enqueueing close on the existing sandesh session
from the state machine of the new sandesh session. In this
case, ensure that the sandesh session connection and state
machine are accessed via mutex to prevent a concurrent delete
of the sandesh session.
